### PR TITLE
bugfix: fix redundant checks and enforce ipaddr without mask

### DIFF
--- a/htdocs/luci-static/resources/view/https-dns-proxy/overview.js
+++ b/htdocs/luci-static/resources/view/https-dns-proxy/overview.js
@@ -331,7 +331,7 @@ return view.extend({
 		o.optional = true;
 
 		o = s.option(form.Value, "listen_addr", _("Listen Address"));
-		o.datatype = "ipaddr";
+		o.datatype = "ipaddr('nomask')";
 		o.default = "";
 		o.optional = true;
 		o.placeholder = "127.0.0.1";
@@ -353,13 +353,13 @@ return view.extend({
 		o.optional = true;
 
 		o = s.option(form.Value, "dscp_codepoint", _("DSCP Codepoint"));
-		o.datatype = "and(uinteger, range(0,63))";
+		o.datatype = "range(0,63)";
 		o.default = "";
 		o.modalonly = true;
 		o.optional = true;
 
 		o = s.option(form.Value, "verbosity", _("Logging Verbosity"));
-		o.datatype = "and(uinteger, range(0,4))";
+		o.datatype = "range(0,4)";
 		o.default = "";
 		o.modalonly = true;
 		o.optional = true;
@@ -370,7 +370,7 @@ return view.extend({
 		o.optional = true;
 
 		o = s.option(form.Value, "polling_interval", _("Polling Interval"));
-		o.datatype = "and(uinteger, range(5,3600))";
+		o.datatype = "range(5,3600)";
 		o.default = "";
 		o.modalonly = true;
 		o.optional = true;


### PR DESCRIPTION
and(uinteger, range(1,2))
is synonymous with
range(1,2)

neither https-dns-proxy, nor dnsmasq accept 127.0.0.1/32, so prohibit mask for ipaddr datatype. Otherwise it will wreak havoc :)