### PR TITLE
bugfix: fix templates loading when no templates found

### DIFF
--- a/htdocs/luci-static/resources/https-dns-proxy/status.js
+++ b/htdocs/luci-static/resources/https-dns-proxy/status.js
@@ -25,7 +25,7 @@ var pkg = {
 		);
 	},
 	templateToRegexp: function (template) {
-		return RegExp(
+		if(template) return RegExp(
 			"^" +
 				template
 					.split(/(\{\w+\})/g)
@@ -37,9 +37,11 @@ var pkg = {
 					.join("") +
 				"$"
 		);
+		return RegExp();
 	},
 	templateToResolver: function (template, args) {
-		return template.replace(/{(\w+)}/g, (_, v) => args[v]);
+		if(template) return template.replace(/{(\w+)}/g, (_, v) => args[v]);
+		return;
 	},
 };
 
@@ -157,8 +159,8 @@ var status = baseclass.extend({
 					force_dns_active: null,
 					version: null,
 				},
-				providers: (data[1] && data[1][pkg.Name]) || { providers: [] },
-				runtime: (data[2] && data[2][pkg.Name]) || { instances: [] },
+				providers: (data[1] && data[1][pkg.Name]) || [{ title: "empty" }],
+				runtime: (data[2] && data[2][pkg.Name]) || { instances: null, triggers: [] },
 			};
 			reply.providers.sort(function (a, b) {
 				return _(a.title).localeCompare(_(b.title));

--- a/htdocs/luci-static/resources/view/https-dns-proxy/overview.js
+++ b/htdocs/luci-static/resources/view/https-dns-proxy/overview.js
@@ -29,7 +29,7 @@ return view.extend({
 				http2_support: null,
 				http3_support: null,
 			},
-			providers: (data[1] && data[1][pkg.Name]) || { providers: [] },
+			providers: (data[1] && data[1][pkg.Name]) || [{ title: "empty" }],
 		};
 		reply.providers.sort(function (a, b) {
 			return _(a.title).localeCompare(_(b.title));

--- a/htdocs/luci-static/resources/view/status/include/71_https-dns-proxy.js
+++ b/htdocs/luci-static/resources/view/status/include/71_https-dns-proxy.js
@@ -26,8 +26,8 @@ return baseclass.extend({
 				force_dns_active: null,
 				version: null,
 			},
-			providers: (data[1] && data[1][pkg.Name]) || { providers: [] },
-			runtime: (data[2] && data[2][pkg.Name]) || { instances: [] },
+			providers: (data[1] && data[1][pkg.Name]) || [{ title: "empty" }],
+			runtime: (data[2] && data[2][pkg.Name]) || { instances: null, triggers: [] },
 		};
 		reply.providers.sort(function (a, b) {
 			return _(a.title).localeCompare(_(b.title));


### PR DESCRIPTION
in the line:
	`providers: (data[1] && data[1][pkg.Name]) || { providers: [] },`

this logical or happens after the 'providers:' part. That is, the providers object now contains another object containing another providers. Empty providers causes chaos anyway at every use of `reply.providers` since it isn't reachable.

Many errors cascade after that. Fix by providing an empty array (instead of another object)