### PR TITLE
 luci-app-https-dns-proxy: fix restena.lu DoH server URL

### DIFF
--- a/root/usr/share/https-dns-proxy/providers/lu.restena.kaitain.json
+++ b/root/usr/share/https-dns-proxy/providers/lu.restena.kaitain.json
@@ -1,7 +1,7 @@
 {
 	"title": "Restena DNS (LU)",
-	"template": "https://kaitain.restena.lu/dns-query",
+	"template": "https://dnspub.restena.lu/dns-query",
 	"bootstrap_dns": "1.1.1.1,1.0.0.1,2606:4700:4700::1111,2606:4700:4700::1001,8.8.8.8,8.8.4.4,2001:4860:4860::8888,2001:4860:4860::8844",
-	"help_link": "https://www.restena.lu/en/service/public-dns-resolver",
+	"help_link": "https://www.restena.lu/en/document/190-configuring-your-server-public-dns-resolver",
 	"http2_only": true
 }


### PR DESCRIPTION
Per https://github.com/openwrt/luci/pull/7608#issuecomment-2646662655, opening PR here.

This changes endpoint URL for DoH to a working one, per the service documentation: https://www.restena.lu/en/document/190-configuring-your-server-public-dns-resolver