### PR TITLE
Update: ffmuc bootstrap_dns servers

### DIFF
--- a/root/usr/share/https-dns-proxy/providers/net.ffmuc.doh.json
+++ b/root/usr/share/https-dns-proxy/providers/net.ffmuc.doh.json
@@ -1,6 +1,6 @@
 {
 	"title": "FFMUC DNS (DE)",
 	"template": "https://doh.ffmuc.net/dns-query",
-	"bootstrap_dns": "1.1.1.1,1.0.0.1,2606:4700:4700::1111,2606:4700:4700::1001,8.8.8.8,8.8.4.4,2001:4860:4860::8888,2001:4860:4860::8844",
+	"bootstrap_dns": "5.1.66.255,185.150.99.255,2001:678:e68:f000::,2001:678:ed0:f000::",
 	"help_link": "https://ffmuc.net/wiki/doku.php?id=knb:dohdot"
 }


### PR DESCRIPTION
this updates the ffmuc bootstrap_dns to ffmuc dns servers instead of google or cloudflare dns

Update ffmuc doh bootstrap_dns to ffmuc dns servers
See Servers: https://ffmuc.net/wiki/doku.php?id=knb:dohdot
Here is our wiki Page about "normal" DNS: https://ffmuc.net/wiki/doku.php?id=knb:dns